### PR TITLE
add multiSig for whitelisted officers to approve the bid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smart Contracts Implementation for Procurement
+# Smart Contracts Implementation for Procurement Procedures (Open Tenders)
 
 ## Background
 This project is a part of the MH6814 Blockchain II group project assignment. Our team has explored the feasibility of replacing the traditional procurement process used by the Singapore Government with a blockchain-based smart contract system. Our aim is to enhance transparency, efficiency, and automation in the procurement process using Ethereum blockchain technology.

--- a/contracts/ApprovalWorkflow.sol
+++ b/contracts/ApprovalWorkflow.sol
@@ -1,53 +1,102 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./BidEvaluation.sol"; // Import the BidEvaluation contract
+import "./BidEvaluation.sol"; // Import the BidEvaluation contract if it's in a separate file
 
 contract ApprovalWorkflow {
     BidEvaluation bidEvaluationContract; // Instance of the BidEvaluation contract
-
+    address public owner;
+    mapping(address => bool) public whitelist; // Tracks whitelisted officer addresses
+    
     enum ApprovalStatus { Pending, Approved, Rejected }
     struct BidApproval {
         uint256 rfpId;
         address vendor;
         ApprovalStatus status;
     }
-
+    
+    struct ApprovalData {
+        uint256 approvalCount;
+        mapping(address => bool) approvers;
+        bool isApproved;
+        bool isRejected;
+    }
+    
     mapping(uint256 => BidApproval) public approvals;
+    mapping(uint256 => ApprovalData) private approvalData;
+    
+    uint256 public constant MIN_APPROVALS = 2;
 
     event BidApproved(uint256 indexed rfpId, address indexed vendor);
     event BidRejected(uint256 indexed rfpId, address indexed vendor);
+    event OfficerAddedToWhitelist(address officer);
+    event OfficerRemovedFromWhitelist(address officer);
 
     constructor(address _bidEvaluationContractAddress) {
         bidEvaluationContract = BidEvaluation(_bidEvaluationContractAddress);
+        owner = msg.sender; // Setting the deployer as the owner
     }
 
-    // Function to approve a bid
-    function approveBid(uint256 _rfpId, address _vendor) public {
+    modifier onlyWhitelisted() {
+        require(whitelist[msg.sender], "Caller is not whitelisted");
+        _;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Caller is not the owner");
+        _;
+    }
+
+    modifier notAlreadyApproved(uint256 _rfpId) {
+        require(!approvalData[_rfpId].approvers[msg.sender], "Officer has already approved this bid");
+        _;
+    }
+
+    function addToWhitelist(address _officer) public onlyOwner {
+        whitelist[_officer] = true;
+        emit OfficerAddedToWhitelist(_officer);
+    }
+
+    function removeFromWhitelist(address _officer) public onlyOwner {
+        whitelist[_officer] = false;
+        emit OfficerRemovedFromWhitelist(_officer);
+    }
+
+    function approveBid(uint256 _rfpId, address _vendor) public onlyWhitelisted notAlreadyApproved(_rfpId) {
         require(bidEvaluationContract.isWinningBid(_rfpId, _vendor), "Vendor is not the winning bidder");
 
-        approvals[_rfpId] = BidApproval({
-            rfpId: _rfpId,
-            vendor: _vendor,
-            status: ApprovalStatus.Approved
-        });
+        ApprovalData storage data = approvalData[_rfpId];
+        data.approvers[msg.sender] = true;
+        data.approvalCount++;
 
-        emit BidApproved(_rfpId, _vendor);
+        if (data.approvalCount >= MIN_APPROVALS && !data.isApproved) {
+            approvals[_rfpId] = BidApproval({
+                rfpId: _rfpId,
+                vendor: _vendor,
+                status: ApprovalStatus.Approved
+            });
+            data.isApproved = true;
+            emit BidApproved(_rfpId, _vendor);
+        }
     }
 
-    // Function to reject a bid
-    function rejectBid(uint256 _rfpId, address _vendor) public {
+    function rejectBid(uint256 _rfpId, address _vendor) public onlyWhitelisted notAlreadyApproved(_rfpId) {
         require(bidEvaluationContract.isWinningBid(_rfpId, _vendor), "Vendor is not the winning bidder");
 
-        approvals[_rfpId] = BidApproval({
-            rfpId: _rfpId,
-            vendor: _vendor,
-            status: ApprovalStatus.Rejected
-        });
+        ApprovalData storage data = approvalData[_rfpId];
+        data.approvers[msg.sender] = true;
+        data.approvalCount++;
 
-        emit BidRejected(_rfpId, _vendor);
+        if (data.approvalCount >= MIN_APPROVALS && !data.isRejected) {
+            approvals[_rfpId] = BidApproval({
+                rfpId: _rfpId,
+                vendor: _vendor,
+                status: ApprovalStatus.Rejected
+            });
+            data.isRejected = true;
+            emit BidRejected(_rfpId, _vendor);
+        }
     }
-
     // Function to check the approval status of a bid
     function getApprovalStatus(uint256 _rfpId) public view returns (ApprovalStatus) {
         return approvals[_rfpId].status;

--- a/contracts/ContractExecution.sol
+++ b/contracts/ContractExecution.sol
@@ -55,7 +55,7 @@ contract ContractExecution {
     }
 
     // Function to mark a milestone as completed and transfer funds
-    function completeMilestone(uint256 _rfpId) public {
+    function completeMilestone(uint256 _rfpId) public onlyOwner{
         Contract storage contractToUpdate = contracts[_rfpId];
         require(contractToUpdate.isActive, "Contract is not active");
         require(contractToUpdate.milestonesCompleted < contractToUpdate.totalMilestones, "All milestones already completed");

--- a/contracts/RFPIssuance.sol
+++ b/contracts/RFPIssuance.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract RFPIssuance {
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract RFPIssuance is Ownable(msg.sender){
     struct RFP {
         uint256 id;
         string title;
@@ -18,7 +20,7 @@ contract RFPIssuance {
     event RFPDeactivated(uint256 indexed rfpId);
 
     // Function to issue a new RFP
-    function issueRFP(string memory _title, string memory _description, uint256 _deadline) public {
+    function issueRFP(string memory _title, string memory _description, uint256 _deadline) public onlyOwner{
         require(_deadline > block.timestamp, "Deadline should be in the future");
 
         RFP memory newRFP = RFP({
@@ -35,7 +37,7 @@ contract RFPIssuance {
     }
 
     // Function to update an RFP
-    function updateRFP(uint256 _rfpId, string memory _title, string memory _description) public {
+    function updateRFP(uint256 _rfpId, string memory _title, string memory _description) public onlyOwner{
         require(rfps[_rfpId].isActive, "RFP is not active");
         rfps[_rfpId].title = _title;
         rfps[_rfpId].description = _description;
@@ -44,7 +46,7 @@ contract RFPIssuance {
     }
 
     // Function to deactivate an RFP
-    function deactivateRFP(uint256 _rfpId) public {
+    function deactivateRFP(uint256 _rfpId) public onlyOwner{
         require(rfps[_rfpId].isActive, "RFP is already inactive");
         rfps[_rfpId].isActive = false;
 


### PR DESCRIPTION
Key Modifications and Additions
**Whitelist Management:** Added functions addToWhitelist and removeFromWhitelist to manage which officers are allowed to approve or reject bids, with corresponding events for tracking these actions.
**Multi-Signature Approval: I**ntroduced ApprovalData struct to track the count of approvals for each bid and which officers have approved it. The approveBid and rejectBid functions now require a minimum of two approvals before changing the bid's status, ensuring no single officer can unilaterally approve or reject a bid.
**Status Flags:** Added boolean flags isApproved and isRejected within ApprovalData to prevent a bid from being approved and then rejected (or vice versa) after reaching the minimum approval count.
Modifiers: Implemented notAlreadyApproved to prevent an officer from