### PR TITLE
add reentrancy guard to ContractExecution.sol

### DIFF
--- a/contracts/ContractExecution.sol
+++ b/contracts/ContractExecution.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "./ApprovalWorkflow.sol"; // Import the ApprovalWorkflow contract
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract ContractExecution {
+contract ContractExecution is ReentrancyGuard{
     ApprovalWorkflow approvalWorkflowContract; // Instance of the ApprovalWorkflow contract
     address public owner;
 

--- a/contracts/ContractExecution.sol
+++ b/contracts/ContractExecution.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./ApprovalWorkflow.sol"; // Import the ApprovalWorkflow contract
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 contract ContractExecution {
     ApprovalWorkflow approvalWorkflowContract; // Instance of the ApprovalWorkflow contract
@@ -55,7 +56,7 @@ contract ContractExecution {
     }
 
     // Function to mark a milestone as completed and transfer funds
-    function completeMilestone(uint256 _rfpId) public onlyOwner{
+    function completeMilestone(uint256 _rfpId) public onlyOwner nonReentrant{
         Contract storage contractToUpdate = contracts[_rfpId];
         require(contractToUpdate.isActive, "Contract is not active");
         require(contractToUpdate.milestonesCompleted < contractToUpdate.totalMilestones, "All milestones already completed");


### PR DESCRIPTION

To further mitigate the risk of reentrancy attacks, particularly in the context of the ContractExecution contract where financial transactions occur, implementing a reentrancy guard would be a prudent measure. The ReentrancyGuard utility from OpenZeppelin provides an easy and effective way to prevent reentrancy into functions.